### PR TITLE
fixed the storing of wifi info

### DIFF
--- a/ATEM_tally_light/ATEM_tally_light.ino
+++ b/ATEM_tally_light/ATEM_tally_light.ino
@@ -169,8 +169,11 @@ void setup() {
     Serial.println("########################");
     Serial.println("Serial started");
 
+    //save flash memory from being written too without need.
+    //WiFi.persistent(false); // PSK Per the ESP documentation, flash will only be written to if the WiFi parameters change.. Its ok to leave on
+
     //Read settings from EEPROM. Settings struct takes 72 bytes total (according to sizeof()). WIFI settings are stored seperately by the ESP
-    EEPROM.begin(72); //Needed on ESP8266 module, as EEPROM lib works a bit differently than on a regular arduino
+    EEPROM.begin(sizeof(settings)); //Needed on ESP8266 module, as EEPROM lib works a bit differently than on a regular arduino
     EEPROM.get(0, settings);
 
     //Initialize LED strip
@@ -205,9 +208,9 @@ void setup() {
     FastLED.show();
 
     Serial.println(settings.tallyName);
-    //Serial.println(sizeof(settings)); //Check size of settings struct
 
-    WiFi.persistent(false);
+    // PSK WiFi.persistent(false); // PSK Per the ESP documentation, flash will only be written to if the WiFi parameters change.. Its ok to leave on
+
     if (settings.staticIP) {
         WiFi.config(settings.tallyIP, settings.tallyGateway, settings.tallySubnetMask);
     }
@@ -256,7 +259,9 @@ void loop() {
             } else if (firstRun) {
                 firstRun = false;
                 Serial.println("Unable to connect. Serving \"Tally Light setup\" WiFi for configuration, while still trying to connect...");
-                WiFi.mode(WIFI_AP_STA); // Enable softAP to access web interface in case of no WiFi
+                // PSK WiFi.mode(WIFI_AP_STA); // Enabling both AP and STA mode at the same time WITH AutoReconnect() caused a ton of errors and time 
+                // PSK consuming code deep in the ESP32 code, changing to just AP served and process the config page must faster while in AP mode
+                WiFi.mode(WIFI_AP); // Just use as AP until someone connects to the webpage and submits, then change to WIFI_STA
                 WiFi.softAP("Tally Light setup");
                 setBothLEDs(LED_WHITE);
                 setStatusLED(LED_WHITE);
@@ -341,6 +346,8 @@ void loop() {
 
     //Handle web interface
     server.handleClient();
+
+    delay(100);
 }
 
 //Handle the change of states in the program
@@ -740,14 +747,20 @@ void handleSave() {
 
             server.send(200, "text/html", (String)"<!DOCTYPE html><html><head><meta charset=\"ASCII\"><meta name=\"viewport\"content=\"width=device-width, initial-scale=1.0\"><title>Tally Light setup</title></head><body><table bgcolor=\"#777777\"border=\"0\"width=\"100%\"cellpadding=\"1\"style=\"font-family:Verdana;color:#ffffff;font-size:.8em;\"><tr><td><h1>&nbsp;Tally Light setup</h1></td></tr></table><br>Settings saved successfully.</body></html>");
 
-            //Delay to let data be saved, and the responce to be sent properly to the client
-            delay(5000);
+            // Delay to let data be saved, and the response to be sent properly to the client
+            server.close(); // PSK Close allowed me to ensure the response got to the client and take the delay down from 5000 ms to 100 ms
+            delay(100);
 
-            if (ssid && pwd && (ssid != getSSID() || pwd != WiFi.psk())) {
-                WiFi.persistent(true);
-                WiFi.begin(ssid.c_str(), pwd.c_str());
+            // Change from AP mode into STA mode to try to connect to your router
+            WiFi.mode(WIFI_STA); // Disable softAP if connection is successful
+            delay(100); // Give it time to switch over to STA mode (this is important on the ESP32 at least
+
+            if (ssid && pwd) {
+                // PSK Pass in false so we don't waste time trying to connect, just save the new SSID/PSK
+                wl_status_t status = WiFi.begin(ssid.c_str(), pwd.c_str(),false);
             }
 
+            delay(100);
             ESP.restart();
         }
     }


### PR DESCRIPTION
There were a few issues with the underlying ESP32 WiFi code to work around. Turning on verbose logging helped see a lot of extra stuff going on and out of sequence things.

1- calls to WiFi.persistent( false ) and then to true were not necessary. According to the documentation the ESP will not update the SSID/PSK in EEPROM as long as they do not change. The setting back and forth confused the ESP32 code and it would not save for some reason. I didn't look that deep, but removing the calls to WiFi.persistent(false) fixed things

2- Putting the board in AP and Station mode at the same time (AP_STA) confused the ESP32 with AutoReconnect set to true. This caused delays in connecting to the AP, serving web pages and saving -- maybe other things as well. I changed this to put it in only AP mode if it can't connect via Station, then switch back to Station after the WiFi config has been updated. Now connecting to the AP and config page is fast and reliable.

3- I needed to add a few delay()s in the saving code to get the ESP32 to switch over from AP mode to STA mode during the saving of the config. To compensate, I trimmed down the existing 4 second save and added a server.close() before it which flushed the connection (at least on the ESP32)

You code is awesome, and very easy to walk though. Thanks for making this available to the public! Let me know if this doesn't work on your ESP, my email is my git account on gmail if you want to chat directly.